### PR TITLE
Distribution version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
             steps {
                 script {
                     VERSION = TAG_NAME[1..-1]
+                }
                 sh "docker tag ${GIT_COMMIT} dtr.fintlabs.no/beta/linkwalker:${VERSION}"
                 withDockerRegistry([credentialsId: 'dtr-fintlabs-no', url: 'https://dtr.fintlabs.no']) {
                     sh "docker push dtr.fintlabs.no/beta/linkwalker:${VERSION}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
             steps {
                 sh "docker tag ${GIT_COMMIT} dtr.fintlabs.no/beta/linkwalker:latest"
                 withDockerRegistry([credentialsId: 'dtr-fintlabs-no', url: 'https://dtr.fintlabs.no']) {
-                    sh "docker push 'dtr.fintlabs.no/beta/linkwalker:latest'"
+                    sh "docker push dtr.fintlabs.no/beta/linkwalker:latest"
                 }
                 withDockerServer([credentialsId: "ucp-fintlabs-jenkins-bundle", uri: "tcp://ucp.fintlabs.no:443"]) {
                      sh "docker service update customer-portal-beta_linkwalker --image dtr.fintlabs.no/beta/linkwalker:latest --detach=false"
@@ -23,16 +23,20 @@ pipeline {
             steps {
                 sh "docker tag ${GIT_COMMIT} dtr.fintlabs.no/beta/linkwalker:${BRANCH_NAME}"
                 withDockerRegistry([credentialsId: 'dtr-fintlabs-no', url: 'https://dtr.fintlabs.no']) {
-                    sh "docker push 'dtr.fintlabs.no/beta/linkwalker:${BRANCH_NAME}'"
+                    sh "docker push dtr.fintlabs.no/beta/linkwalker:${BRANCH_NAME}"
                 }
             }
         }
-        stage('Publish Tag') {
-            when { buildingTag() }
+        stage('Publish Version') {
+            when {
+                tag pattern: "v\\d+\\.\\d+\\.\\d+(-\\w+-\\d+)?", comparator: "REGEXP"
+            }
             steps {
-                sh "docker tag ${GIT_COMMIT} dtr.fintlabs.no/beta/linkwalker:${TAG_NAME}"
+                script {
+                    VERSION = TAG_NAME[1..-1]
+                sh "docker tag ${GIT_COMMIT} dtr.fintlabs.no/beta/linkwalker:${VERSION}"
                 withDockerRegistry([credentialsId: 'dtr-fintlabs-no', url: 'https://dtr.fintlabs.no']) {
-                    sh "docker push 'dtr.fintlabs.no/beta/linkwalker:${TAG_NAME}'"
+                    sh "docker push dtr.fintlabs.no/beta/linkwalker:${VERSION}"
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ For protected resources, the following environment variables must be set with va
 | `fint.oauth.client-secret`    | OAuth Client Secret                               |
 | `fint.oauth.scope`            | Set to `fint-client`                              |
 
-Example access token server URI: https://namidp01.rogfk.no/nidp/oauth/nam/token
+Example access token server URI: https://idp.felleskomponent.no/nidp/oauth/nam/token
 
 Example request URL: https://beta.felleskomponent.no/administrasjon/personal

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Verifies relation links for a given resource.
 
 Edit the supplied `docker-compose.yml` to add OAuth credentials, and use `docker-compose up` to start.
 
+Open a browser at http://localhost:8082/swagger-ui.html 
+
 ## Usage
 
-Launching this application starts a web server at port `8080` with the following endpoints:
+Launching this application starts a web server at port `8082` with the following endpoints:
 
 | Path                    | Method    | Description       |
 |-------------------------|-----------|-------------------|

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Open a browser at http://localhost:8082/swagger-ui.html
 
 Launching this application starts a web server at port `8082` with the following endpoints:
 
-| Path                    | Method    | Description       |
-|-------------------------|-----------|-------------------|
-| /api/tests/links        | GET       | Get all tests     |
-| /api/tests/links        | POST      | Start a new test, returns location header with direct url to the test  |
-| /api/tests/links/{id}   | GET       | Get test with id  |
+The `org` path parameter can be any value you choose.
+
+| Path                          | Method | Description       |
+|-------------------------------|--------|-------------------|
+| `/api/tests/links/{org}`      | GET    | Get all tests     |
+| `/api/tests/links/{org}`      | POST   | Start a new test, returns location header with direct url to the test  |
+| `/api/tests/links/{org}/{id}` | GET    | Get test with id  |
 
 ## Model
 
@@ -25,6 +27,7 @@ The POST method requires a JSON object with the following elements:
     {
         "baseUrl": "https://api.felleskomponent.no",
         "endpoint": "/administrasjon/personal/personalressurs",
+        "client": "client",
         "orgId": "pwf.no"
     }
     
@@ -32,6 +35,7 @@ The POST method requires a JSON object with the following elements:
 |----------|-------------------------------------|
 | baseUrl  | Base URL for access.                |
 | endpoint | Data endpoint to verify.            |
+| client   | Some name for the client            |
 | orgId    | Organization ID to verify data for. |
 
 Base URL can be one of the following:
@@ -39,6 +43,12 @@ Base URL can be one of the following:
   - https://beta.felleskomponent.no                  
   - https://play-with-fint.felleskomponent.no        
 
+Endpoint refer to data elements, here are some examples:
+
+  - `/administrasjon/personal/person`
+  - `/administrasjon/personal/personalressurs`
+  - `/utdanning/elev/person`
+  - `/utdanning/elev/elev`
 
 ## OAuth 2.0 Environment variables
 
@@ -47,13 +57,11 @@ For protected resources, the following environment variables must be set with va
 | Variable                      | Content                                           |
 |-------------------------------|---------------------------------------------------|
 | `fint.oauth.enabled`          | Set to `true` to enable OAuth                     | 
+| `fint.oauth.access-token-uri` | URI of access token server                        |
+| `fint.oauth.scope`            | Set to `fint-client`                              |
 | `fint.oauth.username`         | User Name                                         |
 | `fint.oauth.password`         | Password                                          |
-| `fint.oauth.access-token-uri` | URI of access token server                        |
 | `fint.oauth.client-id`        | OAuth Client ID                                   |
 | `fint.oauth.client-secret`    | OAuth Client Secret                               |
-| `fint.oauth.scope`            | Set to `fint-client`                              |
 
 Example access token server URI: https://idp.felleskomponent.no/nidp/oauth/nam/token
-
-Example request URL: https://beta.felleskomponent.no/administrasjon/personal

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ repositories {
 
 dependencies {
     compile('no.fint:fint-oauth-token-service:1.4.0')
-    compile('no.fint:fint-portal-api:3.2.0')
     compileOnly("org.projectlombok:lombok:${lombokVersion}")
     compile('com.jayway.jsonpath:json-path:2.4.0')
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,6 @@ services:
   link-walker:
     image: dtr.fintlabs.no/beta/linkwalker
     ports:
-      - 8080:8080
+      - 8082:8082
     environment:
       TZ: Europe/Oslo
-      fint.oauth.enabled: "true"
-      fint.oauth.scope: fint-client
-      fint.oauth.access-token-uri: https://idp.felleskomponent.no/nidp/oauth/nam/token
-      fint.oauth.username:
-      fint.oauth.password:
-      fint.oauth.client-id:
-      fint.oauth.client-secret:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  link-walker:
+    image: dtr.fintlabs.no/beta/linkwalker
+    ports:
+      - 8080:8080
+    environment:
+      TZ: Europe/Oslo
+      fint.oauth.enabled: "true"
+      fint.oauth.scope: fint-client
+      fint.oauth.access-token-uri: https://idp.felleskomponent.no/nidp/oauth/nam/token
+      fint.oauth.username:
+      fint.oauth.password:
+      fint.oauth.client-id:
+      fint.oauth.client-secret:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,12 @@ version: '3'
 
 services:
   link-walker:
-    image: dtr.fintlabs.no/beta/linkwalker
+    image: dtr.fintlabs.no/beta/linkwalker:PR-10
     ports:
       - 8082:8082
     environment:
       TZ: Europe/Oslo
+#      fint.oauth.username:
+#      fint.oauth.password:
+#      fint.oauth.client-id:
+#      fint.oauth.client-secret:

--- a/src/main/java/no/fint/linkwalker/TestController.java
+++ b/src/main/java/no/fint/linkwalker/TestController.java
@@ -9,7 +9,6 @@ import no.fint.linkwalker.dto.TestRequest;
 import org.apache.poi.util.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -18,7 +17,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponents;
-import sun.nio.ch.IOUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/main/java/no/fint/linkwalker/TestController.java
+++ b/src/main/java/no/fint/linkwalker/TestController.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 @Slf4j
 @RestController
 @CrossOrigin
-@RequestMapping("/api/tests/links/{organisation}")
+@RequestMapping("/api/tests/links/{organisation:.+}")
 public class TestController {
 
     @Autowired

--- a/src/main/java/no/fint/linkwalker/TestRunner.java
+++ b/src/main/java/no/fint/linkwalker/TestRunner.java
@@ -6,9 +6,6 @@ import no.fint.linkwalker.dto.Status;
 import no.fint.linkwalker.dto.TestCase;
 import no.fint.linkwalker.dto.TestRequest;
 import no.fint.linkwalker.exceptions.FintLinkWalkerException;
-import no.fint.oauth.OAuthRestTemplateFactory;
-import no.fint.portal.model.client.Client;
-import no.fint.portal.model.client.ClientService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.http.client.ClientHttpResponse;
@@ -21,18 +18,12 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
 
 @Slf4j
 @Service
 public class TestRunner {
 
     @Autowired
-    private OAuthRestTemplateFactory oAuthRestTemplateFactory;
-
-    @Autowired
-    private ClientService clientService;
-
     private RestTemplate restTemplate;
 
     @Async
@@ -43,17 +34,6 @@ public class TestRunner {
             return;
         } else {
             log.info("Running test {}", target);
-        }
-
-        if (PwfUtils.isPwf(testCase.getTestRequest().getBaseUrl())) {
-            restTemplate = new RestTemplate();
-        } else {
-            Client client = clientService.getClientByDn(testCase.getTestRequest().getClient()).orElseThrow(SecurityException::new);
-            String password = UUID.randomUUID().toString().toLowerCase();
-            clientService.resetClientPassword(client, password);
-            String clientSecret = clientService.getClientSecret(client);
-
-            restTemplate = oAuthRestTemplateFactory.create(client.getName(), password, client.getClientId(), clientSecret);
         }
 
         setRestTemplateErrorHandler();

--- a/src/main/java/no/fint/linkwalker/dto/TestCase.java
+++ b/src/main/java/no/fint/linkwalker/dto/TestCase.java
@@ -3,6 +3,7 @@ package no.fint.linkwalker.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import no.fint.linkwalker.DiscoveredRelation;
 import no.fint.linkwalker.TestedRelation;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 @Getter
+@ToString(of = {"id", "status"})
 public class TestCase {
 
     private final UUID id;


### PR DESCRIPTION
This version of the link walker can be used externally, since it doesn't require access to the LDAP server.

It should not be merged until we have solved both internal and external distribution.