### PR TITLE
Retry requests and configurable authorization strategy

### DIFF
--- a/src/main/java/no/fint/linkwalker/OAuthTokenRestTemplateProvider.java
+++ b/src/main/java/no/fint/linkwalker/OAuthTokenRestTemplateProvider.java
@@ -1,0 +1,34 @@
+package no.fint.linkwalker;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.PostConstruct;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(name = "fint.rest-template.provider", havingValue = "oauth", matchIfMissing = true)
+public class OAuthTokenRestTemplateProvider extends RestTemplateProvider {
+
+    @Autowired
+    private OAuth2RestTemplate restTemplate;
+
+    @PostConstruct
+    public void init() {
+        log.info("Authorization using Resource Owner credentials enabled.");
+    }
+
+    @Override
+    public RestTemplate getRestTemplate() {
+        return withPermissiveErrorHandler(new RestTemplate());
+    }
+
+    @Override
+    public RestTemplate getAuthRestTemplate(String client) {
+        return restTemplate;
+    }
+}

--- a/src/main/java/no/fint/linkwalker/PortalApiRestTemplateProvider.java
+++ b/src/main/java/no/fint/linkwalker/PortalApiRestTemplateProvider.java
@@ -1,0 +1,65 @@
+package no.fint.linkwalker;
+
+import lombok.extern.slf4j.Slf4j;
+import no.fint.oauth.OAuthRestTemplateFactory;
+import no.fint.portal.model.client.Client;
+import no.fint.portal.model.client.ClientService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.PostConstruct;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+@Service
+@Slf4j
+@ConditionalOnProperty(name = "fint.rest-template.provider", havingValue = "portal-api")
+public class PortalApiRestTemplateProvider extends RestTemplateProvider {
+
+    @Autowired
+    private ClientService clientService;
+
+    @Autowired
+    private OAuthRestTemplateFactory oAuthRestTemplateFactory;
+
+    private final ConcurrentMap<String, OAuth2RestTemplate> restTemplateCache = new ConcurrentSkipListMap<>();
+
+    @PostConstruct
+    public void init() {
+        log.info("Authorization using Portal API enabled.");
+    }
+
+    @Override
+    public RestTemplate getRestTemplate() {
+        return withPermissiveErrorHandler(new RestTemplate());
+    }
+
+    @Override
+    public RestTemplate getAuthRestTemplate(String client) {
+        return withPermissiveErrorHandler(restTemplateCache.compute(client, this::computeOAuthRestTemplate));
+    }
+
+    private OAuth2RestTemplate computeOAuthRestTemplate(String client, OAuth2RestTemplate restTemplate) {
+        if (restTemplate == null
+                || restTemplate.getOAuth2ClientContext() == null
+                || restTemplate.getOAuth2ClientContext().getAccessToken() == null
+                || restTemplate.getOAuth2ClientContext().getAccessToken().isExpired()) {
+            return createOAuthRestTemplate(client);
+        }
+        return restTemplate;
+    }
+
+    private OAuth2RestTemplate createOAuthRestTemplate(String clientDn) {
+        Client client = clientService.getClientByDn(clientDn).orElseThrow(SecurityException::new);
+        String password = UUID.randomUUID().toString().toLowerCase();
+        clientService.resetClientPassword(client, password);
+        String clientSecret = clientService.getClientSecret(client);
+
+        return oAuthRestTemplateFactory.create(client.getName(), password, client.getClientId(), clientSecret);
+    }
+
+}

--- a/src/main/java/no/fint/linkwalker/ResourceFetcher.java
+++ b/src/main/java/no/fint/linkwalker/ResourceFetcher.java
@@ -1,0 +1,50 @@
+package no.fint.linkwalker;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+public class ResourceFetcher {
+    private static final double MULTIPLIER = Math.sqrt(2);
+    private static final int LIMIT = 10;
+
+    @Autowired
+    private RestTemplateProvider restTemplateProvider;
+
+    public <T> ResponseEntity<T> fetch(String client, String location, HttpHeaders headers, Class<T> type) {
+        int count = 0;
+        long delay = 1000;
+        do {
+            try {
+                ++count;
+                RestTemplate restTemplate = getRestTemplate(client, location);
+                return restTemplate.exchange(location, HttpMethod.GET, new HttpEntity<>(headers), type);
+            } catch (ResourceAccessException e) {
+                log.info(e.getMessage());
+                log.info("Retry {}/{} in {} ms ...", count, LIMIT, delay);
+                try {
+                    TimeUnit.MILLISECONDS.sleep(delay);
+                } catch (InterruptedException e1) {
+                    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+                }
+                delay *= MULTIPLIER;
+            }
+        } while (count < LIMIT);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+    }
+
+    private RestTemplate getRestTemplate(String client, String location) {
+        if (PwfUtils.isPwf(location)) {
+            return restTemplateProvider.getRestTemplate();
+        }
+        return restTemplateProvider.getAuthRestTemplate(client);
+    }
+
+}

--- a/src/main/java/no/fint/linkwalker/RestTemplateProvider.java
+++ b/src/main/java/no/fint/linkwalker/RestTemplateProvider.java
@@ -1,47 +1,15 @@
 package no.fint.linkwalker;
 
-import no.fint.oauth.OAuthRestTemplateFactory;
-import no.fint.portal.model.client.Client;
-import no.fint.portal.model.client.ClientService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.UUID;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListMap;
+public abstract class RestTemplateProvider {
+    public abstract RestTemplate getRestTemplate();
 
-@Service
-public class RestTemplateProvider {
+    public abstract RestTemplate getAuthRestTemplate(String client);
 
-    @Autowired
-    private ClientService clientService;
-
-    @Autowired
-    private OAuthRestTemplateFactory oAuthRestTemplateFactory;
-
-    private final ConcurrentMap<String, RestTemplate> restTemplateCache = new ConcurrentSkipListMap<>();
-
-    public RestTemplate getRestTemplate() {
-        return withPermissiveErrorHandler(new RestTemplate());
-    }
-
-    public RestTemplate getAuthRestTemplate(String client) {
-        return restTemplateCache.computeIfAbsent(client, this::createAuthRestTemplate);
-    }
-
-    private RestTemplate createAuthRestTemplate(String clientDn) {
-        Client client = clientService.getClientByDn(clientDn).orElseThrow(SecurityException::new);
-        String password = UUID.randomUUID().toString().toLowerCase();
-        clientService.resetClientPassword(client, password);
-        String clientSecret = clientService.getClientSecret(client);
-
-        return withPermissiveErrorHandler(oAuthRestTemplateFactory.create(client.getName(), password, client.getClientId(), clientSecret));
-    }
-
-    private RestTemplate withPermissiveErrorHandler(RestTemplate input) {
+    protected RestTemplate withPermissiveErrorHandler(RestTemplate input) {
         input.setErrorHandler(new ResponseErrorHandler() {
             @Override
             public boolean hasError(ClientHttpResponse response) {
@@ -56,5 +24,4 @@ public class RestTemplateProvider {
 
         return input;
     }
-
 }

--- a/src/main/java/no/fint/linkwalker/RestTemplateProvider.java
+++ b/src/main/java/no/fint/linkwalker/RestTemplateProvider.java
@@ -1,0 +1,60 @@
+package no.fint.linkwalker;
+
+import no.fint.oauth.OAuthRestTemplateFactory;
+import no.fint.portal.model.client.Client;
+import no.fint.portal.model.client.ClientService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+@Service
+public class RestTemplateProvider {
+
+    @Autowired
+    private ClientService clientService;
+
+    @Autowired
+    private OAuthRestTemplateFactory oAuthRestTemplateFactory;
+
+    private final ConcurrentMap<String, RestTemplate> restTemplateCache = new ConcurrentSkipListMap<>();
+
+    public RestTemplate getRestTemplate() {
+        return withPermissiveErrorHandler(new RestTemplate());
+    }
+
+    public RestTemplate getAuthRestTemplate(String client) {
+        return restTemplateCache.computeIfAbsent(client, this::createAuthRestTemplate);
+    }
+
+    private RestTemplate createAuthRestTemplate(String clientDn) {
+        Client client = clientService.getClientByDn(clientDn).orElseThrow(SecurityException::new);
+        String password = UUID.randomUUID().toString().toLowerCase();
+        clientService.resetClientPassword(client, password);
+        String clientSecret = clientService.getClientSecret(client);
+
+        return withPermissiveErrorHandler(oAuthRestTemplateFactory.create(client.getName(), password, client.getClientId(), clientSecret));
+    }
+
+    private RestTemplate withPermissiveErrorHandler(RestTemplate input) {
+        input.setErrorHandler(new ResponseErrorHandler() {
+            @Override
+            public boolean hasError(ClientHttpResponse response) {
+                return false;
+            }
+
+            @Override
+            public void handleError(ClientHttpResponse response) {
+                return;
+            }
+        });
+
+        return input;
+    }
+
+}


### PR DESCRIPTION
This PR adds request retries with exponential backoff.

In addition, the authorization strategy is now configurable, and can be selected between OAuth Resource Owner Password credentials (the default) or Portal API.

With this in place the `dist` branch could be merged, so both internal and external use of the link walker is supported from the same codebase.